### PR TITLE
Added Android support

### DIFF
--- a/dependencies/android/build.gradle
+++ b/dependencies/android/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+	repositories {
+		jcenter {
+			url "http://jcenter.bintray.com/"
+		}
+	}
+	
+	dependencies {
+		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_PLUGIN::'
+	}
+}
+
+apply plugin: 'com.android.library'
+
+android {
+	compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+	buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
+}
+
+dependencies {
+	compile project(':deps:extension-api')
+}

--- a/dependencies/android/src/main/AndroidManifest.xml
+++ b/dependencies/android/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.haxe.extension.safearea" >
+	
+	
+	
+</manifest>

--- a/dependencies/android/src/main/java/org/haxe/extension/NotchAndroid.java
+++ b/dependencies/android/src/main/java/org/haxe/extension/NotchAndroid.java
@@ -24,18 +24,11 @@ public class NotchAndroid extends Extension {
 
 	public void onCreate (Bundle savedInstanceState) {
 		insets = new float[4];
-	}
-
-	public static void disable_letterbox(){
+		
 		if (Build.VERSION.SDK_INT >= 28) {
-			mainActivity.runOnUiThread(new Runnable(){
-				@Override
-				public void run(){
-					Window win = mainActivity.getWindow();
-					win.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-					win.getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
-				}
-			});
+			Window win = mainActivity.getWindow();
+			win.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+			win.getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
 		}
 	}
 

--- a/dependencies/android/src/main/java/org/haxe/extension/NotchAndroid.java
+++ b/dependencies/android/src/main/java/org/haxe/extension/NotchAndroid.java
@@ -1,0 +1,71 @@
+package org.haxe.extension;
+
+import android.util.Log;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+import org.haxe.lime.HaxeObject;
+import android.view.WindowInsets;
+import android.view.WindowManager;
+import android.view.DisplayCutout;
+import android.view.View.OnApplyWindowInsetsListener;
+
+
+public class NotchAndroid extends Extension {
+
+	public static NotchAndroid inst = null;
+	public float[] insets;
+
+	public NotchAndroid(){
+		super();
+		inst = this;
+	}
+
+	public void onCreate (Bundle savedInstanceState) {
+		insets = new float[4];
+	}
+
+	public static void disable_letterbox(){
+		if (Build.VERSION.SDK_INT >= 28) {
+			mainActivity.runOnUiThread(new Runnable(){
+				@Override
+				public void run(){
+					Window win = mainActivity.getWindow();
+					win.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+					win.getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+				}
+			});
+		}
+	}
+
+	public float[] updateSafeArea(){
+		if (Build.VERSION.SDK_INT >= 28) {
+			Window win = mainActivity.getWindow();
+			if(win == null) return null;
+
+			View root = win.getDecorView().getRootView();
+			if(root == null) return null;
+
+			WindowInsets ins = root.getRootWindowInsets();
+			if(ins == null) return null;
+
+			DisplayCutout cutout = ins.getDisplayCutout();
+
+			if(cutout != null){
+				insets[0] = (float) cutout.getSafeInsetTop();
+				insets[1] = (float) cutout.getSafeInsetBottom();
+				insets[2] = (float) cutout.getSafeInsetLeft();
+				insets[3] = (float) cutout.getSafeInsetRight();
+			}else{
+				//no cutout
+				insets[0] = 0;
+				insets[1] = 0;
+				insets[2] = 0;
+				insets[3] = 0;
+			}
+		}
+
+		return insets;
+	}
+}

--- a/extension/safearea/SafeArea.hx
+++ b/extension/safearea/SafeArea.hx
@@ -25,19 +25,9 @@ class SafeArea
 	public static var paddingRight(default, null):Float;
 	public static var safeArea(default, null):Rectangle;
 
-	/**
-		The parameter `disableAndroidLetterBox` can be set to false if you want the OS to add
-		a letter-box around the notch/cutout(s).
-	*/
-	public static function init(disableAndroidLetterbox:Bool = true)
+	public static function init()
 	{
 		stage = openfl.Lib.current.stage;
-
-		#if android
-		if(disableAndroidLetterbox){
-			safearea_disable_letterbox();
-		}
-		#end
 
 		update();
 
@@ -96,7 +86,6 @@ class SafeArea
 	#elseif android
 	static var safearea_instance = JNI.createStaticField("org/haxe/extension/NotchAndroid", "inst", "Lorg/haxe/extension/NotchAndroid;");
 	static var safearea_update = JNI.createMemberMethod("org.haxe.extension.NotchAndroid", "updateSafeArea", "()[F");
-	static var safearea_disable_letterbox = JNI.createStaticMethod("org.haxe.extension.NotchAndroid", "disable_letterbox", "()V");
 	#end
 
 }

--- a/include.xml
+++ b/include.xml
@@ -3,4 +3,13 @@
 
 	<ndll name="safearea" if="ios" />
 
+	<section if="android">
+		<dependency
+			name="notch"
+			path="dependencies/android"
+			if="android"
+		/>
+		<android extension="org.haxe.extension.NotchAndroid" />
+	</section>
+
 </project>


### PR DESCRIPTION
Added support for handling cutouts/notches on Android. 

~~Note that I modified the `SafeArea.init` function with a parameter to control letterboxing on Android:~~


> ~~public static function init(disableAndroidLetterbox:Bool = true)~~

~~The reason for this is that Android adds letterboxes by default. In order to reclaim that space, you need to make changes to the app's Window flags/attributes. The way I do it in this extension is probably fine for most OpenFL users, but if someone has a custom activity or extension, they might want to set those flags themselves. Calling `SafeArea.init` with `false` will skip the part that updates the Window.~~

EDIT: On second thought, adding the ability to leave the letterboxing isn't going to work without a lot more work than is probably worth the effort. If someone is making a custom activity for their app, it'll likely be easier for them to deal with that themselves than it is to do it from the life cycle of an OpenFL extension.

The implementation I had used `Activity.runOnUiThread` as that's the only way to update the Window from the extension. This causes a race condition which can't be properly dealt with without changing the API of this extension to, for example, use a callback, promises, etc.

So the current version will just update the Window during `onCreate`

Tested On:
 * Android Pie Emulator w/ API level 29
 * Google Pixel 3 XL w/ 9
 * Nexus 4 w/ Android 5.1.1

Didn't test on iOS, but I didn't change anything in the existing code.